### PR TITLE
fix the permission manually in the container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ./zoo-project/zoo-services/utils/open-api/templates/index.html:/var/www/index.html
       - ./zoo-project/zoo-services/utils/open-api/static:/var/www/html/static
       - ./docker/com:/usr/com/zoo-project
-      - zTmp:/tmp/zTmp
+      - ./docker/tmp:/tmp/zTmp
     depends_on:
       - pgbouncer
       - redis
@@ -31,7 +31,7 @@ services:
     volumes:
       - ./docker/main.cfg:/usr/lib/cgi-bin/main.cfg
       - ./docker/oas.cfg:/usr/lib/cgi-bin/oas.cfg
-      - zTmp:/tmp/zTmp
+      - ./docker/tmp:/tmp/zTmp
       - ./docker/com:/usr/com/zoo-project
     depends_on:
       - rabbitmq
@@ -88,11 +88,3 @@ services:
     ports:
       - "15672:15672"
       - "5672:5672"
-
-volumes:
-  zTmp:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind,uid=33,gid=33
-      device: $PWD/docker/tmp

--- a/docker/startUp.sh
+++ b/docker/startUp.sh
@@ -2,6 +2,11 @@
 # Author: Gérald Fenoy
 # Copyright GeoLabs 2021
 
+mkdir -p /tmp/zTmp/statusInfos
+cp /var/www/html/data/* /usr/com/zoo-project
+chown www-data:www-data -R /tmp/zTmp /usr/com/zoo-project
+chmod 777 -R /tmp/zTmp
+
 CMD="curl -o toto.out http://rabbitmq:15672"
 $CMD
 cat toto.out


### PR DESCRIPTION
Revert to using short-syntax bind mounts for maximum compatibility and manually fix the shared directories in the container