### PR TITLE
Fix error message generation

### DIFF
--- a/zoo-project/zoo-kernel/response_print.h
+++ b/zoo-project/zoo-kernel/response_print.h
@@ -205,7 +205,7 @@ extern "C" {
     },
     {
       "400 Bad request",
-      "MissingParameterValue"
+      "MissingParameterValue",
       "InvalidParameterValue",
       "InvalidUpdateSequence",
       "OptionNotSupported",


### PR DESCRIPTION
# Overview
When trying to execute a Zoo-project service with an unknow identifier, the server returns an HTTP 500 error and produces a Core Dump.
The same issue appears when on execution on a Python service when a module is missing.


# Contributions and Licensing

(as per https://zoo-project.github.io/docs/contribute/howto.html#licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.
- [x] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
