### PR TITLE
GSoC2023:Updated build.sh file

### DIFF
--- a/docker/ets-ogcapi-processes/build.sh
+++ b/docker/ets-ogcapi-processes/build.sh
@@ -37,3 +37,4 @@ cd ../../..
 docker build . -f docker/ets-ogcapi-processes/Dockerfile --progress plain -t zooproject/ets-ogcapi-processes10:latest
 
 sed "s/localhost/zookernel/g" -i docker/*.cfg
+sed "s=<organization>=<config><organization>=g;s=</organization>=</organization></config>=g" -i docker/ets-ogcapi-processes/src1/ets-ogcapi-processes10/src/main/config/teamengine/config.xml


### PR DESCRIPTION
# Overview

Updated `build.sh` file

# Related Issue / Discussion

Added command `sed "s=<organization>=<config><organization>=g;s=</organization>=</organization></config>=g" -i docker/ets-ogcapi-processes/src1/ets-ogcapi-processes10/src/main/config/teamengine/config.xml` in `build.sh` file

# Additional Information

# Contributions and Licensing

(as per https://zoo-project.github.io/docs/contribute/howto.html#licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.
- [X] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
