### PR TITLE
Load lib error

### DIFF
--- a/zoo-project/zoo-kernel/caching.c
+++ b/zoo-project/zoo-kernel/caching.c
@@ -229,14 +229,14 @@ void cacheFile(maps* conf,char* request,char* mimeType,int length,char* filename
       fo=fopen(fname,"w+");
       if(fo==NULL){
 #ifdef DEBUG
-	fprintf (stderr, "Failed to open %s for writing: %s\n",fname, strerror(errno));
+	fprintf (stderr, "Failed to open %s for writing: %s\n",fname);
 #endif
 	unlockFile(conf,lck);
 	return;
       }
       if(fi==NULL){
 #ifdef DEBUG
-	fprintf (stderr, "Failed to open %s for reading: %s\n",filename, strerror(errno));
+	fprintf (stderr, "Failed to open %s for reading: %s\n",filename);
 #endif
 	unlockFile(conf,lck);
 	return;
@@ -308,7 +308,7 @@ void addToCache(maps* conf,char* request,char* content,char* mimeType,int length
       FILE* fo=fopen(fname,"w+");
       if(fo==NULL){
 #ifdef DEBUG
-	fprintf (stderr, "Failed to open %s for writing: %s\n",fname, strerror(errno));
+	fprintf (stderr, "Failed to open %s for writing: %s\n",fname);
 #endif
 	filepath = NULL;
 	unlockFile(conf,lck);

--- a/zoo-project/zoo-kernel/caching.c
+++ b/zoo-project/zoo-kernel/caching.c
@@ -229,14 +229,14 @@ void cacheFile(maps* conf,char* request,char* mimeType,int length,char* filename
       fo=fopen(fname,"w+");
       if(fo==NULL){
 #ifdef DEBUG
-	fprintf (stderr, "Failed to open %s for writing: %s\n",fname);
+	fprintf (stderr, "Failed to open %s for writing\n",fname);
 #endif
 	unlockFile(conf,lck);
 	return;
       }
       if(fi==NULL){
 #ifdef DEBUG
-	fprintf (stderr, "Failed to open %s for reading: %s\n",filename);
+	fprintf (stderr, "Failed to open %s for reading\n",filename);
 #endif
 	unlockFile(conf,lck);
 	return;
@@ -308,7 +308,7 @@ void addToCache(maps* conf,char* request,char* content,char* mimeType,int length
       FILE* fo=fopen(fname,"w+");
       if(fo==NULL){
 #ifdef DEBUG
-	fprintf (stderr, "Failed to open %s for writing: %s\n",fname);
+	fprintf (stderr, "Failed to open %s for writing\n");
 #endif
 	filepath = NULL;
 	unlockFile(conf,lck);

--- a/zoo-project/zoo-kernel/service.c
+++ b/zoo-project/zoo-kernel/service.c
@@ -1356,7 +1356,7 @@ elements* dupElements(elements* peElem){
   if(peCursor!=NULL && peCursor->name!=NULL){
 #ifdef DEBUG
     fprintf(stderr,">> %s %i\n",__FILE__,__LINE__);
-    dumpMap(peCursor->defaults->content);
+    dumpMap(peCursor->content);
     fprintf(stderr,">> %s %i\n",__FILE__,__LINE__);
 #endif
     peTmp=(elements*)malloc(ELEMENTS_SIZE);

--- a/zoo-project/zoo-kernel/service.c
+++ b/zoo-project/zoo-kernel/service.c
@@ -1356,7 +1356,7 @@ elements* dupElements(elements* peElem){
   if(peCursor!=NULL && peCursor->name!=NULL){
 #ifdef DEBUG
     fprintf(stderr,">> %s %i\n",__FILE__,__LINE__);
-    dumpElements(e);
+    dumpMap(peCursor->defaults->content);
     fprintf(stderr,">> %s %i\n",__FILE__,__LINE__);
 #endif
     peTmp=(elements*)malloc(ELEMENTS_SIZE);

--- a/zoo-project/zoo-kernel/zoo_service_loader.c
+++ b/zoo-project/zoo-kernel/zoo_service_loader.c
@@ -1670,12 +1670,13 @@ loadServiceAndRun (maps ** myMap, service * s1, map * request_inputs,
    */
   char *serviceNamespacePath=NULL;
   if(request_output_real_format!=NULL){
-    serviceNamespacePath=(char*)malloc(1024*sizeof(char));
+
     //memset(serviceNamespacePath,'\0',1024);
     map* zooServicesNamespaceMap= getMapFromMaps(m, "zooServicesNamespace", "namespace");
     map* zooServicesNamespacePathMap=getMapFromMaps(m,"servicesNamespace","path");
 
     if( zooServicesNamespaceMap && strlen(zooServicesNamespaceMap->value)>0 && zooServicesNamespacePathMap && strlen(zooServicesNamespacePathMap->value)>0){
+      serviceNamespacePath=(char*)malloc(1024*sizeof(char));
       sprintf(serviceNamespacePath,"%s/%s",zooServicesNamespacePathMap->value,zooServicesNamespaceMap->value);
       setMapInMaps(m, "lenv","cwd", serviceNamespacePath);
     }


### PR DESCRIPTION
# Overview

While starting a new service executed by a FPM, the getStatus service return the following error:
```xml
<?xml version="1.0" encoding="utf-8"?>
<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd" xml:lang="en-US" version="1.1.0">
    <ows:Exception exceptionCode="InternalError">
        <ows:ExceptionText>Unable to load C Library (null)</ows:ExceptionText>
    </ows:Exception>
</ows:ExceptionReport>
```
The error is due to a test on the nulity of a string whereas a malloc is always perform for this string but a value is not always copy in this string. So a memory space is used in the case of C libraries loading (like getStatus service) with weird data that create the issue.

Also some code compilations errors appear when activating the DEBUG mode.

# Contributions and Licensing

(as per https://zoo-project.github.io/docs/contribute/howto.html#licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.
- [x] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
