### PR TITLE
Cookiecutter Template Branch Customizable + zoo-calrissian-runner dependency update

### DIFF
--- a/docker/dru/Dockerfile
+++ b/docker/dru/Dockerfile
@@ -35,6 +35,7 @@ COPY docker/dru/ades-dev_env.yaml /tmp/ades-dev_env.yaml
 RUN conda install mamba -n base -c conda-forge && \
     mamba env create --file /tmp/ades-dev_env.yaml &&\
     rm /tmp/ades-dev_env.yaml
+RUN ln -s /usr/miniconda3/envs/ades-dev/bin/kubectl /usr/bin/kubectl
 
 ########################################
 # ZOO_Prerequisites

--- a/docker/dru/ades-dev_env.yaml
+++ b/docker/dru/ades-dev_env.yaml
@@ -11,7 +11,7 @@ dependencies:
   - cookiecutter=1.7.2
   - boto3
   - pycalrissian
-  - zoo-calrissian-runner=0.1.7
+  - zoo-calrissian-runner=0.1.8
   - python-kubernetes
   - cwl-wrapper=0.10.1
   - coverage

--- a/docker/dru/ades-dev_env.yaml
+++ b/docker/dru/ades-dev_env.yaml
@@ -13,7 +13,7 @@ dependencies:
   - pycalrissian
   - zoo-calrissian-runner=0.1.8
   - python-kubernetes
-  - cwl-wrapper=0.10.1
+  - cwl-wrapper=0.12.1
   - coverage
   - pip
   - pip:

--- a/zoo-project/zoo-services/utils/open-api/dru/DeployProcess.py
+++ b/zoo-project/zoo-services/utils/open-api/dru/DeployProcess.py
@@ -95,6 +95,10 @@ class DeployService(object):
             key="templateUrl", section="cookiecutter"
         )
 
+        self.cookiecutter_template_branch = self._get_conf_value_if_exists(
+            key="templateBranch", section="cookiecutter"
+        )
+
         self.tmp_folder = self._get_conf_value("tmpPath")
 
         self.process_id = self.conf["lenv"]["usid"]
@@ -145,6 +149,14 @@ class DeployService(object):
         else:
             raise ValueError(f"{key} not set, check configuration")
 
+    def _get_conf_value_if_exists(self, key, section="main"):
+
+        print(section, file=sys.stderr)
+        if key in self.conf[section].keys():
+            return self.conf[section][key]
+        else:
+            return None
+
     @staticmethod
     def check_write_permissions(folder):
 
@@ -192,10 +204,19 @@ class DeployService(object):
 
                 # checking if template had already been cloned
                 if os.path.isdir(template_folder):
-
                     shutil.rmtree(template_folder)
 
-                os.system(f"git clone {self.cookiecutter_template_url} {template_folder}")
+                # retrieving the branch to clone
+                # if no branch is specified, we will clone the master branch
+                cookiecutter_template_branch = self.cookiecutter_template_branch
+
+                # cloning the template
+                if cookiecutter_template_branch is not None:
+                    os.system(
+                        f"git clone -b {cookiecutter_template_branch} {self.cookiecutter_template_url} {template_folder}"
+                    )
+                else:
+                    os.system(f"git clone {self.cookiecutter_template_url} {template_folder}")
 
             else:
                 raise ValueError(


### PR DESCRIPTION
# zoo-project-dru:  Cookiecutter Template Branch Customizable

## Overview

This pull request enhances the `zoo-project-dru` Helm chart values by allowing the specification of a Git branch when setting the `cookiecutter` template URL. This addition offers flexibility in choosing the branch from which to clone the cookiecutter template. If no branch is specified, it will default to 'master'.
 For instance:

```yaml
cookiecutter:
  templateUrl: https://github.com/EOEPCA/proc-service-template.git
  templateBranch: zoo-project-dru
```

## Changes Made

### DeployProcess.py 

(`zoo-project/zoo-services/utils/open-api/dru/DeployProcess.py`):
- Added a new method named `_get_conf_value_if_exists` that retrieves a configuration value and returns `None` if the configuration does not exist.
- Introduced a line calling the new method to fetch the template branch.
- Updated the `git clone` command to set the branch if the `templateBranch` configuration property is specified.

## Testing

### Testing Plan

To verify this feature:

1. Build the `ZooProject-DRU` on Minikube's Docker registry:

```shell
eval $(minikube docker-env)
docker build . -f docker/dru/Dockerfile -t zoo-project/zoo-project-dru:template-branch-feature --no-cache
```

2. In `zoo-project-dru/values_minikube.yaml` of the `zoo-project-dru` Helm chart, set the tag of the new Docker image:

```yaml
zoofpm:
  image:
    repository: zoo-project/zoo-project-dru
    pullPolicy: IfNotPresent
    tag: template-branch-feature

zookernel:
  image:
    repository: zoo-project/zoo-project-dru
    pullPolicy: IfNotPresent
    tag: template-branch-feature
```

3. Update or add the `cookiecutter` section in `zoo-project-dru/values_minikube.yaml` by specifying the branch:

```yaml
cookiecutter:
  templateUrl: https://github.com/EOEPCA/proc-service-template.git
  templateBranch: zoo-project-dru
```

4. Deploy the `zoo-project-dru` Helm chart:

```shell
helm upgrade --install zoo-project-dru zoo-project-dru/ -f zoo-project-dru/values_minikube.yaml -n zp --create-namespace
```

5. Deploy a service.

6. Access the `zoofpm` pod, navigate to the deployed services folder, and confirm that the service deployed in the previous step was generated using the cookiecutter template from the 'zoo-project-dru' branch.

# zoo-project-dru: Update of zoo-calrissian-runner dependency

Zoo-calrissian-runner version 0.1.8 has better support for inputs passed by the zoo-kernel, in particular for those of type array.


# Related Issue / Discussion

https://github.com/ZOO-Project/charts/pull/7

# Additional Information

# Contributions and Licensing

(as per https://zoo-project.github.io/docs/contribute/howto.html#licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.
- [x] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
