### PR TITLE
Additional defensive dictionary key checks for security_service.py

### DIFF
--- a/zoo-project/zoo-services/utils/security/jwt/cgi-env/security_service.py
+++ b/zoo-project/zoo-services/utils/security/jwt/cgi-env/security_service.py
@@ -49,14 +49,20 @@ def securityIn(main_conf,inputs,outputs):
             print(sToken,file=sys.stderr)
             if sToken.count(".")>=2:
                 cJWT=main_conf["renv"][i].split(' ')[1]
-                if main_conf["renv"][i].count("oidc/"+main_conf["osecurity"]["realm"]+"/")>0:
-                    cJWT=cJWT.replace("oidc/"+main_conf["osecurity"]["realm"]+"/","")
+                if "osecurity" in main_conf and "realm" in main_conf["osecurity"]:
+                    if main_conf["renv"][i].count("oidc/"+main_conf["osecurity"]["realm"]+"/")>0:
+                        cJWT=cJWT.replace("oidc/"+main_conf["osecurity"]["realm"]+"/","")
                 jsonObj=jwt.decode(cJWT, options={"verify_signature": False,"verify_aud": False})
                 hasAuth=True
                 myKeys=list(jsonObj.keys())
                 for k in jsonObj.keys():
-                    if k.count("username")>0:
-                        if "osecurity" in main_conf and "allowed_users" in main_conf["osecurity"] and main_conf["osecurity"]["allowed_users"].split(",").count(jsonObj["preferred_username"])==0:
+                    if k.count("username")>0 or k.count("user_name")>0:
+                        if "osecurity" in main_conf and \
+                           "allowed_users" in main_conf["osecurity"] and \
+                           "preferred_username" in jsonObj and \
+                           main_conf["osecurity"]["allowed_users"].split(",").count(jsonObj["preferred_username"])==0:
+                            if "lenv" not in main_conf:
+                                main_conf["lenv"] = {}
                             main_conf["lenv"]["message"]=zoo._("You are not authorized to perform the requested operation on the resource (jwt.securityIn).")
                             main_conf["lenv"]["code"]="Forbidden"
                             main_conf["lenv"]["status"]="403 Forbidden"
@@ -66,49 +72,69 @@ def securityIn(main_conf,inputs,outputs):
                                 main_conf["headers"]={"status":"403 Forbidden"}
                         main_conf["auth_env"]={"user": jsonObj[k] }
                         break
+                if "auth_env" not in main_conf:
+                    main_conf["auth_env"] = {}
                 if "email" in jsonObj.keys():
                     main_conf["auth_env"]["email"]=jsonObj["email"]
                 for l in range(len(myKeys)):
                     main_conf["auth_env"][myKeys[l]]=str(jsonObj[myKeys[l]])
                 main_conf["auth_env"]["jwt"]=cJWT
+                if "lenv" not in main_conf:
+                    main_conf["lenv"] = {}
                 main_conf["lenv"]["json_user"]=json.dumps(jsonObj)
             else:
                 import requests
-                if "userinfoUrl" not in main_conf["osecurity"]:
+                if "osecurity" in main_conf and \
+                   "userinfoUrl" not in main_conf["osecurity"]:
                     import base64
-                    try:
-                        b64=base64.b64encode((main_conf["osecurity"]["client_id"]+":"+main_conf["osecurity"]["client_secret"]).encode("ascii")).decode('ascii')
-                    except Exception as e:
-                        print(e,file=sys.stderr)
+                    b64 = ""
+                    if "client_id" in main_conf["osecurity"] and \
+                       "client_secret" in main_conf["osecurity"]:
+                        try:
+                            b64=base64.b64encode((main_conf["osecurity"]["client_id"]+":"+main_conf["osecurity"]["client_secret"]).encode("ascii")).decode('ascii')
+                        except Exception as e:
+                            print(e,file=sys.stderr)
+                            if "servicesNamespace" in main_conf and "debug" in main_conf["servicesNamespace"]:
+                                print("b64 encoding error: " + str(e), file=sys.stderr)
+                                print(traceback.format_exc())
                     headers = {"Authorization" : "Basic "+b64, "Acccept": "application/json","Content-Type": "application/x-www-form-urlencoded"}
                     data= {"token": sToken,"token_type_hint": "access_token"}
                     response=requests.post("https://www.authenix.eu/oauth/tokeninfo",data=data,headers=headers)
                     userObject=json.loads(response.text)
-                    if userObject["active"]:
+                    if userObject["active"] and "sub" in userObject:
+                        if "auth_env" not in main_conf:
+                            main_conf["auth_env"] = {}
                         main_conf["auth_env"]={"user": userObject["sub"]}
                         hasAuth=True
                 else:
-                    headers = {"Authorization" : "Bearer "+sToken, "Acccept": "application/json"}
-                    response=requests.get(main_conf["osecurity"]["userinfoUrl"],headers=headers)
-                    userObject=json.loads(response.text)
-                    main_conf["auth_env"]={"jwt": sToken}
-                    for a in userObject.keys():
-                        main_conf["auth_env"][a]=userObject[a]
-                    if "user_name" not in main_conf["auth_env"]:
-                        main_conf["auth_env"]["user"]=userObject["sub"]
-                    else:
-                        main_conf["auth_env"]["user"]=main_conf["auth_env"]["user_name"]
-                    hasAuth=True
+                    if "osecurity" in main_conf and "userinfoUrl" in main_conf["osecurity"]:
+                        headers = {"Authorization" : "Bearer "+sToken, "Acccept": "application/json"}
+                        response=requests.get(main_conf["osecurity"]["userinfoUrl"],headers=headers)
+                        userObject=json.loads(response.text)
+                        if "auth_env" not in main_conf:
+                            main_conf["auth_env"] = {}
+                        main_conf["auth_env"]={"jwt": sToken}
+                        for a in userObject.keys():
+                            main_conf["auth_env"][a]=userObject[a]
+                        if "user_name" not in main_conf["auth_env"]:
+                            if "sub" in userObject:
+                                main_conf["auth_env"]["user"]=userObject["sub"]
+                                hasAuth=True
+                        else:
+                            main_conf["auth_env"]["user"]=main_conf["auth_env"]["user_name"]
+                            hasAuth=True
             break
-    if "auth_env" in main_conf:
+    if "auth_env" in main_conf and "user" in main_conf:
         main_conf["renv"]["SERVICES_NAMESPACE"]=main_conf["auth_env"]["user"]
-    if hasAuth or main_conf["lenv"]["secured_url"]=="false":
+    if hasAuth or \
+       ("lenv" in main_conf and "secured_url" in main_conf["lenv"] and main_conf["lenv"]["secured_url"]=="false"):
         return zoo.SERVICE_SUCCEEDED
     else:
         if "headers" in main_conf:
             main_conf["headers"]["status"]="403 Forbidden"
         else:
             main_conf["headers"]={"status":"403 Forbidden"}
-        main_conf["lenv"]["code"]="NotAllowed"
-        main_conf["lenv"]["message"]="Unable to ensure that you are allowed to access the resource."
+        if "lenv" in main_conf:
+            main_conf["lenv"]["code"]="NotAllowed"
+            main_conf["lenv"]["message"]="Unable to ensure that you are allowed to access the resource."
         return zoo.SERVICE_FAILED


### PR DESCRIPTION
# Overview

Added some additional code guards to avoid attempted access to missing dictionary keys during securityIn handling - which was causing exceptions.

# Related Issue / Discussion

Problems (exceptions) were experienced during integration of zoo-dru with eoepca deployment (via helm chart) - perhaps due to the fact that `iam: false` is set, but the expectation remains to receive a JWT via headers.

As a local workaround we use a locally modified version of `zoo-project/zoo-services/utils/security/jwt/cgi-env/security_service.py` rather than calling the upstream function. Would be better to rely upon the upstream version.

# Additional Information

# Contributions and Licensing

(as per https://zoo-project.github.io/docs/contribute/howto.html#licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.
- [ ] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
