### PR TITLE
Add custom layout and assets section, shorten Hugo documentation

### DIFF
--- a/docs/contribute/hugo.rst
+++ b/docs/contribute/hugo.rst
@@ -91,7 +91,7 @@ Steps to Use Custom Layouts
 1. Create a layout file (e.g., new-page.html) in themes/<your-theme>/layouts/
 2. Edit the Markdown File:
 
-   In your .md file (e.g., new-page.md), specify the custom layout in the front matter
+   - In your .md file (e.g., new-page.md), specify the custom layout in the front matter
 
    .. code:: yaml
 

--- a/docs/contribute/hugo.rst
+++ b/docs/contribute/hugo.rst
@@ -93,6 +93,7 @@ Steps to Use Custom Layouts
 
    - In your .md file (e.g., new-page.md), specify the custom layout in the front matter
 
+
    .. code:: yaml
 
       ---

--- a/docs/contribute/hugo.rst
+++ b/docs/contribute/hugo.rst
@@ -90,7 +90,8 @@ Steps to Use Custom Layouts
 
 1. Create a layout file (e.g., new-page.html) in themes/<your-theme>/layouts/
 2. Edit the Markdown File:
-   - In your .md file (e.g., new-page.md), specify the custom layout in the front matter:
+
+   In your .md file (e.g., new-page.md), specify the custom layout in the front matter
 
    .. code:: yaml
 
@@ -104,6 +105,7 @@ Add Custom CSS/JS
 
 1. Add files in themes/<your-theme>/static/
 2. Reference them in:
+
    - `themes/<theme_name>/layouts/partials/head.html`
    - `themes/<theme_name>/layouts/_default/baseof.html`
 

--- a/docs/contribute/hugo.rst
+++ b/docs/contribute/hugo.rst
@@ -118,7 +118,7 @@ To include the new page in the navigation menu:
       weight = 10
 
 
-Customizing Page Layouts
+Customising Page Layouts
 ------------------------
 
 After creating a new Markdown (.md) file, Hugo automatically displays the content using its default layout template. If no custom layout is defined, the site will use the theme’s predefined rendering logic.

--- a/docs/contribute/hugo.rst
+++ b/docs/contribute/hugo.rst
@@ -16,6 +16,14 @@ Execute the following commands in the terminal:
    git clone https://github.com/ZOO-Project/website.git
    cd website
 
+.. note::
+
+   Changes made to the "Examples" page in the ZOO-Project/website repository  
+   (`https://github.com/ZOO-Project/website <https://github.com/ZOO-Project/website>`_)  
+   must also be reflected in the examples repository  
+   (`https://github.com/ZOO-Project/examples <https://github.com/ZOO-Project/examples>`_)  
+   to ensure consistency between both sources.
+
 
 Installing Hugo
 ---------------

--- a/docs/contribute/hugo.rst
+++ b/docs/contribute/hugo.rst
@@ -93,7 +93,6 @@ Steps to Use Custom Layouts
 
    - In your .md file (e.g., new-page.md), specify the custom layout in the front matter
 
-
    .. code:: yaml
 
       ---

--- a/docs/contribute/hugo.rst
+++ b/docs/contribute/hugo.rst
@@ -98,7 +98,7 @@ To modify an existing page:
    .. code:: bash
 
       git add content/docs/updated-page.md
-      git commit -m "Updated documentation"
+      git commit -m "Updated page"
       git push origin main
 
 Adding Navigation Links
@@ -117,9 +117,36 @@ To include the new page in the navigation menu:
       url = "/docs/new-page/"
       weight = 10
 
-3. Save the file and test the navigation link locally using:
+
+Customizing Page Layouts
+------------------------
+
+After creating a new Markdown (.md) file, Hugo automatically displays the content using its default layout template. If no custom layout is defined, the site will use the theme’s predefined rendering logic.
+
+To create a custom layout for a specific section or page:
+
+1. Navigate to the `themes/<theme_name>/layouts/` directory.
+2. Create or edit layout templates based on your content type:
+   - For example: `layouts/_default/single.html` for general content pages.
+   - Or: `layouts/docs/single.html` for documentation-specific pages.
+3. Modify these templates using Hugo’s Go template syntax to define your custom HTML structure.
+
+
+Including Custom CSS and JavaScript
+-----------------------------------
+
+To apply custom styles or add scripts:
+
+1. Place your custom `.css` and `.js` files inside the `static/` directory of the project:
+   - Example: `static/css/custom.css`
+   - Example: `static/js/custom.js`
+
+2. Reference these files in your HTML templates, typically in:
+   - `themes/<theme_name>/layouts/partials/head.html`
+   - or `themes/<theme_name>/layouts/_default/baseof.html`
+
+3. Save the changes and test them with:
 
    .. code:: bash
 
       hugo server
-

--- a/docs/contribute/hugo.rst
+++ b/docs/contribute/hugo.rst
@@ -3,31 +3,22 @@
 Contribute to the Website
 ===================================
 
-This guide provides step-by-step instructions for contributing to the ZOO-Project website using the Hugo static site generator.
+This guide provides step-by-step instructions on how to run the ZOO-Project using the Hugo framework, including installation and implementation within the Hugo project structure.
+`Hugo <https://gohugo.io>`_ is a fast and flexible static site generator written in Go, designed to build websites quickly and efficiently.
 
-Repository Location
--------------------
-
-The source code for the website is hosted on GitHub:
-
-`https://github.com/ZOO-Project/website <https://github.com/ZOO-Project/website>`_
-
-If you're new to the project, this is where all the website content is managed. You will need to clone this repository and set it up locally before making any changes.
-
-Cloning the Repository
+Clone the Repository
 ----------------------
 
-To get started, clone the official repository and navigate into the project folder:
+Execute the following commands in the terminal:
 
 .. code:: bash
 
    git clone https://github.com/ZOO-Project/website.git
    cd website
 
+
 Installing Hugo
 ---------------
-
-The website uses Hugo, a fast static site generator written in Go. You must install Hugo on your system.
 
 Install Hugo by following instructions here: https://gohugo.io/getting-started/installing/
 
@@ -37,22 +28,19 @@ To check if Hugo was installed successfully, run:
 
    hugo version
 
+
 Running the Website Locally
 ---------------------------
-
-To preview the website locally before committing changes:
 
 .. code:: bash
 
    hugo server
 
-Then open your browser at `http://localhost:8080/` to see the live site.
+Visit `http://localhost:8080/` to preview the site.
 
 
 Creating a New Page
 -------------------
-
-To create a new page in the documentation:
 
 1. Navigate to the `content` directory of the Hugo project.
 2. Identify the appropriate section where the new page should be added.
@@ -62,51 +50,30 @@ To create a new page in the documentation:
 
       hugo new docs/new-page.md
 
-4. Open the newly created file in a text editor and add relevant content following Hugo's Markdown syntax.
-5. Ensure the front matter (YAML, TOML, or JSON format) contains necessary metadata, e.g.:
+4. Edit the file and include front matter like:
 
    .. code:: yaml
 
       ---
-      title: "New Page Title"
-      date: 2025-03-11
-      description: "A brief description of the new page."
-      draft: false
+      title = "New Page Title"
+      date = 2025-03-11
+      description = "A brief description of the new page."
+      draft = false
       ---
 
-6. Save the file and preview changes using:
+5. Preview with:
 
    .. code:: bash
 
       hugo server --buildDrafts
 
-Updating an Existing Page
--------------------------
-
-To modify an existing page:
-
-1. Locate the page inside the `content` directory.
-2. Open the file and make necessary changes.
-3. Save the file and verify the updates using:
-
-   .. code:: bash
-
-      hugo server
-
-4. When you're satisfied, commit and push your changes:
-
-   .. code:: bash
-
-      git add content/docs/updated-page.md
-      git commit -m "Updated page"
-      git push origin main
 
 Adding Navigation Links
 -----------------------
 
 To include the new page in the navigation menu:
 
-1. Edit the `config.toml` (or `config.yaml`/`config.json`) file.
+1. Edit the `config.toml` (or `hugo.toml`) file.
 2. Add a reference under `[menu]`:
 
    .. code:: toml
@@ -118,35 +85,33 @@ To include the new page in the navigation menu:
       weight = 10
 
 
-Customising Page Layouts
+Steps to Use Custom Layouts
 ------------------------
 
-After creating a new Markdown (.md) file, Hugo automatically displays the content using its default layout template. If no custom layout is defined, the site will use the theme’s predefined rendering logic.
+1. Create a layout file (e.g., new-page.html) in themes/<your-theme>/layouts/
+2. Edit the Markdown File:
+   - In your .md file (e.g., new-page.md), specify the custom layout in the front matter:
 
-To create a custom layout for a specific section or page:
+   .. code:: yaml
 
-1. Navigate to the `themes/<theme_name>/layouts/` directory.
-2. Create or edit layout templates based on your content type:
-   - For example: `layouts/_default/single.html` for general content pages.
-   - Or: `layouts/docs/single.html` for documentation-specific pages.
-3. Modify these templates using Hugo’s Go template syntax to define your custom HTML structure.
+      ---
+      title = "My Custom Page"
+      layout = "new-page"
+      ---
 
+Add Custom CSS/JS
+-----------------
 
-Including Custom CSS and JavaScript
------------------------------------
-
-To apply custom styles or add scripts:
-
-1. Place your custom `.css` and `.js` files inside the `static/` directory of the project:
-   - Example: `static/css/custom.css`
-   - Example: `static/js/custom.js`
-
-2. Reference these files in your HTML templates, typically in:
+1. Add files in themes/<your-theme>/static/
+2. Reference them in:
    - `themes/<theme_name>/layouts/partials/head.html`
-   - or `themes/<theme_name>/layouts/_default/baseof.html`
+   - `themes/<theme_name>/layouts/_default/baseof.html`
 
 3. Save the changes and test them with:
 
    .. code:: bash
 
+      hugo --minify
       hugo server
+
+


### PR DESCRIPTION
# Overview
This update enhances the Hugo contribution documentation by adding sections on using custom layouts and including custom CSS/JS. It also refactors the content to be more concise and user-friendly.

# Related Issue / Discussion
No issue linked. General documentation improvement.

# Additional Information
Custom layout instructions added (using layout in front matter).
Asset usage explained (static/ directory and layout references).
Rephrased and shortened steps for clarity.
Resolved spacing and formatting issues in .rst structure.

# Contributions and Licensing

(as per https://zoo-project.github.io/docs/contribute/howto.html#licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.
- [x] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
