### PR TITLE
Add GitHub Releases usage and update release documentation

### DIFF
--- a/docs/contribute/release.rst
+++ b/docs/contribute/release.rst
@@ -38,10 +38,10 @@ rules:
 * Once the tag is pushed back to GitHub, make sure to use the 
   "Create release from tag" button on the tag page (accessible from the 
   `Tags list <https://github.com/ZOO-Project/ZOO-Project/tags>`__).
-  Set the release title to "ZOO-Project X.Y.Z" and you may include the 
-  release note as the release description. Before publishing the
-  release, make sure to upload a copy of the archives stored on 
-  zoo-project.org/dl.
+  Set the release title to "ZOO-Project X.Y.Z". Use the consistent release
+  template (see below) to link to the Release Notes wiki page and the
+  official archives. Before publishing the release, make sure to upload a
+  copy of the archives stored on zoo-project.org/dl as release assets.
 * Announce on various email list and other locations
   (news_item@osgeo.org, SlashGeo, etc)
 
@@ -115,8 +115,20 @@ Release versions lead to an update in documentation and standard tarballs. This 
   * Click on "Draft a new release"
   * Select the tag created previously (e.g., rel-1.9.1)
   * Set the release title to "ZOO-Project X.Y.Z"
-  * Include the release notes as the description
+  * Use the following template for the release description:
+
+    .. code-block:: text
+
+       The ZOO-Project X.Y.Z release, please see the release notes for details.
+
+       Release notes: https://github.com/ZOO-Project/ZOO-Project/wiki/Release:-X.Y.Z:-Notes
+
+       Archives ZOO-Project Release X.Y.Z:
+       - http://zoo-project.org/dl/zoo-project-X.Y.Z.tar.bz2
+       - http://zoo-project.org/dl/zoo-project-X.Y.Z.zip
+
   * Upload the archives (``zoo-project-$VERSION.tar.bz2`` and ``zoo-project-$VERSION.zip``) as release assets
+  * If this is a Release Candidate (RC), check "Set as a pre-release"
   * Publish the release
 
   Once published, the archives will be automatically available on the GitHub release page. 

--- a/docs/install/download.rst
+++ b/docs/install/download.rst
@@ -13,10 +13,11 @@ Several ways to download the `ZOO-Project <http://zoo-project.org>`_ source code
 ZOO-Project releases archives
 -------------------------------
 
-Each new `ZOO-Project <http://zoo-project.org>`_ major release are
-available on the project official website as .zip and .tar.bz2
+Each new `ZOO-Project <http://zoo-project.org>`_ release is
+available on the project official website and the `GitHub Releases page <https://github.com/ZOO-Project/ZOO-Project/releases>`_ as .zip and .tar.bz2
 archives. Head to the `Downloads
-<http://zoo-project.org/new/Code/Download>`_ section to get the latest or
+<http://zoo-project.org/resources/download/>`_ section or the
+`GitHub Releases <https://github.com/ZOO-Project/ZOO-Project/releases>`_ page to get the latest or
 older ZOO-Project releases. 
 
 .. warning::


### PR DESCRIPTION
This pull request implements the proposal from issue #11 to use GitHub’s Releases feature for publishing ZOO‑Project versions. It aligns the repository with the documented release procedure and makes future releases easier to discover and manage.

Changes in this PR:

Documented the workflow for creating Git tags and using “Create release from tag” on GitHub, following the current release procedure.
​

Update the release documentation to for reference to GitHub Releases as the canonical location for downloadable archives and release notes.

Add links in the documentation to the GitHub Releases page so users can quickly find past and current releases.

Rationale:

Centralizes release artifacts and notes on GitHub, improving discoverability for users and packagers.
​

Keeps the documented release procedure consistent with actual practice on the repository.

Leverages GitHub’s built‑in tagging and release UI to reduce manual steps during each new ZOO‑Project release.