### PR TITLE
Fix modern build errors (GCC 13+) and update deprecated curl options

### DIFF
--- a/zoo-project/zoo-kernel/service_callback.c
+++ b/zoo-project/zoo-kernel/service_callback.c
@@ -26,6 +26,13 @@
  * THE SOFTWARE.
  */
 
+#ifndef FALSE
+#define FALSE 0
+#endif
+#ifndef TRUE
+#define TRUE 1
+#endif
+
 #include <pthread.h>
 #include <libxml/tree.h>
 #include <libxml/parser.h>

--- a/zoo-project/zoo-kernel/service_internal.c
+++ b/zoo-project/zoo-kernel/service_internal.c
@@ -377,7 +377,7 @@ char* _getStatus(maps* conf,char* lid){
   sprintf (pcaStatusFile, "%s/%s.status", pmInputs->value, lid);
   FILE* f0 = fopen (pcaStatusFile, "r");
   if(f0!=NULL){
-    semid lockid = NULL;
+    semid lockid = -1;
     char* stat;
     long flen;
     stat=getStatusId(conf,lid);
@@ -461,7 +461,7 @@ int _updateStatus(maps *conf){
   if(status!=NULL && msg!=NULL &&
      status->value!=NULL && msg->value!=NULL && 
      strlen(status->value)>0 && strlen(msg->value)>1){    
-    semid lockid = NULL;
+    semid lockid = -1;
     char* stat=getStatusId(conf,pmSid->value);
     if(stat!=NULL){
       lockid=acquireLock(conf);

--- a/zoo-project/zoo-kernel/service_json.c
+++ b/zoo-project/zoo-kernel/service_json.c
@@ -40,6 +40,12 @@
 #include "service_internal_ms.h"
 #endif
 #include <dirent.h>
+#ifndef FALSE
+#define FALSE 0
+#endif
+#ifndef TRUE
+#define TRUE 1
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/zoo-project/zoo-kernel/ulinet.c
+++ b/zoo-project/zoo-kernel/ulinet.c
@@ -569,7 +569,7 @@ HINTERNET InternetOpenUrl(HINTERNET* hInternet,LPCTSTR lpszUrl,LPCTSTR lpszHeade
 #endif
     map* pmMethod=getMapFromMaps((maps*)conf,"lenv","callback_request_method");
     if(pmMethod!=NULL && strcasecmp(pmMethod->value,"PUT")==0)
-	curl_easy_setopt(hInternet->ihandle[hInternet->nb].handle,CURLOPT_PUT,1);
+	curl_easy_setopt(hInternet->ihandle[hInternet->nb].handle,CURLOPT_UPLOAD,1);
     else{
       curl_easy_setopt(hInternet->ihandle[hInternet->nb].handle,CURLOPT_POST,1);
     }


### PR DESCRIPTION
# Overview
This PR provides a set of fixes to ensure the ZOO-Kernel can be compiled on modern Linux distributions (tested on Kali Linux with GCC 13.3.0 and libcurl 8.5.0+). It addresses strict type-checking errors, deprecated library functions, and missing macro definitions.

# Related Issue / Discussion
This was identified during a fresh installation of the ZOO-Project environment for GSoC 2026 preparation. The current main branch fails to link the kernel on newer systems due to a few legacy C patterns that modern compilers now treat as hard errors.

# Additional Information
The following technical adjustments were made:

service_internal.c: Resolved error: initialization of ‘int’ from ‘void *’ by changing semid initialization from NULL to -1.

ulinet.c: Replaced deprecated CURLOPT_PUT with CURLOPT_UPLOAD to comply with modern libcurl standards.

service_json.c & service_callback.c: Added #ifndef guards for TRUE and FALSE macros. This prevents "not declared in this scope" errors when json-c is used in environments that do not globally define these booleans.

Linker Fix: Created a symbolic link for libzoo_service.so.2.0 to allow zoo_loader.cgi to find the shared library at runtime.

# Contributions and Licensing
[x] I'd like to contribute these bugfixes to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.

[ ] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
(as per https://zoo-project.github.io/docs/contribute/howto.html#licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.
- [ ] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
