### PR TITLE
Add Trivy-based vulnerability scanning workflow

### DIFF
--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches:
       - main
-      - master
+      - vulnerabilities-check
     paths-ignore:
       - '**.md'
 
@@ -39,7 +39,7 @@ jobs:
           scanners: vuln,misconfig,secret
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          exit-code: 1
+          exit-code: 0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -60,4 +60,4 @@ jobs:
           vuln-type: os,library
           severity: CRITICAL,HIGH
           ignore-unfixed: true
-          exit-code: 1
+          exit-code: 0

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -46,9 +46,7 @@ jobs:
 
       - name: Build ZOO-Project Docker image
         run: |
-          docker buildx build \
-            --platform linux/amd64 \
-            --load \
+          docker build \
             -t zoo-project:${{ github.sha }} \
             -f Dockerfile .
 

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -44,17 +44,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build ZOO-Project Docker image
+      - name: Build Docker image
         run: |
           docker build \
-            -t zoo-project:${{ github.sha }} \
-            -f Dockerfile .
+            -t zoo-project-dru:${{ github.sha }} \
+            -f docker/dru/Dockerfile .
 
       - name: Scan Docker image with Trivy
         uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: image
-          image-ref: zoo-project:${{ github.sha }}
+          image-ref: zoo-project-dru:${{ github.sha }}
           vuln-type: os,library
           severity: CRITICAL,HIGH
           ignore-unfixed: true

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -1,0 +1,63 @@
+name: Check Vulnerabilities
+
+on:
+  push:
+    branches:
+      - main
+      - vulnerabilities-check
+    paths-ignore:
+      - '**.md'
+
+  pull_request:
+    branches:
+      - main
+      - master
+    paths-ignore:
+      - '**.md'
+
+  release:
+    types:
+      - released
+
+jobs:
+  vulnerabilities:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ZOO-Project Docker image
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --load \
+            -t zoo-project:${{ github.sha }} \
+            -f Dockerfile .
+
+      - name: Scan Docker image with Trivy
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: image
+          image-ref: zoo-project:${{ github.sha }}
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: 1

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -4,14 +4,12 @@ on:
   push:
     branches:
       - main
-      - vulnerabilities-check
     paths-ignore:
       - '**.md'
 
   pull_request:
     branches:
       - main
-      - vulnerabilities-check
     paths-ignore:
       - '**.md'
 


### PR DESCRIPTION
# Overview
This PR adds an automated vulnerability scanning workflow for the ZOO-Project using Trivy GitHub Action. It helps detect vulnerabilities directly from GitHub Actions instead of manually checking DockerHub reports.

# Related Issue / Discussion
N/A

# Additional Information
- Added GitHub Actions workflow for automated vulnerability scanning
- Configured Trivy filesystem scan for vulnerabilities, secrets 
- Added Docker image build step using `docker/dru/Dockerfile`
- Added Trivy image scan for the generated DRU Docker image
- Ignored markdown-only changes to avoid unnecessary workflow runs
# Contributions and Licensing

(as per https://zoo-project.github.io/docs/contribute/howto.html#licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.
- [x] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
