### PR TITLE
Update SARIF upload action to CodeQL v4

### DIFF
--- a/.github/workflows/docker-dru-image.yml
+++ b/.github/workflows/docker-dru-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI (DRU support)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, vulnerabilities-check ]
 
 jobs:
 
@@ -38,12 +38,11 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: ${{ runner.os }}-buildx-
 
-    - name: docker login
-      env:
-        DOCKER_USER: ${{secrets.DOCKER_USER}}
-        DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
-      run: |
-        docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+    - name: Docker login
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Build and push
       uses: docker/build-push-action@v4
@@ -62,7 +61,7 @@ jobs:
         context: .
         push: true
         file: docker/dru/Dockerfile
-        tags: zooproject/zoo-project:dru-${{ github.sha }}
+        tags: anushacs/zoo-project:dru-${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -72,7 +71,7 @@ jobs:
       uses: aquasecurity/trivy-action@0.35.0
       with:
         scan-type: image
-        image-ref: zooproject/zoo-project:dru-${{ github.sha }}
+        image-ref: anushacs/zoo-project:dru-${{ github.sha }}
         vuln-type: os,library
         severity: CRITICAL,HIGH
         ignore-unfixed: true
@@ -91,7 +90,7 @@ jobs:
 
     # Upload SARIF report to GitHub 
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: trivy-results.sarif
 
@@ -102,7 +101,7 @@ jobs:
         context: .
         push: true
         file: docker/dru/Dockerfile
-        tags: zooproject/zoo-project:eoepca-${{ github.sha }}
+        tags: anushacs/zoo-project:eoepca-${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-eoepca-cache
         cache-to: type=local,dest=/tmp/.buildx-eoepca-cache-new,mode=max
 
@@ -129,7 +128,7 @@ jobs:
         context: .
         push: true
         file: docker/dru/Dockerfile
-        tags: zooproject/zoo-project:dru-latest
+        tags: anushacs/zoo-project:dru-latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 

--- a/.github/workflows/docker-dru-image.yml
+++ b/.github/workflows/docker-dru-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI (DRU support)
 
 on:
   push:
-    branches: [ main, vulnerabilities-check ]
+    branches: [ main ]
 
 jobs:
 
@@ -38,11 +38,12 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: ${{ runner.os }}-buildx-
 
-    - name: Docker login
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKER_USER }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: docker login
+      env:
+        DOCKER_USER: ${{secrets.DOCKER_USER}}
+        DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      run: |
+        docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
 
     - name: Build and push
       uses: docker/build-push-action@v4
@@ -61,7 +62,7 @@ jobs:
         context: .
         push: true
         file: docker/dru/Dockerfile
-        tags: anushacs/zoo-project:dru-${{ github.sha }}
+        tags: zooproject/zoo-project:dru-${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
@@ -71,7 +72,7 @@ jobs:
       uses: aquasecurity/trivy-action@0.35.0
       with:
         scan-type: image
-        image-ref: anushacs/zoo-project:dru-${{ github.sha }}
+        image-ref: zooproject/zoo-project:dru-${{ github.sha }}
         vuln-type: os,library
         severity: CRITICAL,HIGH
         ignore-unfixed: true
@@ -101,7 +102,7 @@ jobs:
         context: .
         push: true
         file: docker/dru/Dockerfile
-        tags: anushacs/zoo-project:eoepca-${{ github.sha }}
+        tags: zooproject/zoo-project:eoepca-${{ github.sha }}
         cache-from: type=local,src=/tmp/.buildx-eoepca-cache
         cache-to: type=local,dest=/tmp/.buildx-eoepca-cache-new,mode=max
 
@@ -128,7 +129,7 @@ jobs:
         context: .
         push: true
         file: docker/dru/Dockerfile
-        tags: anushacs/zoo-project:dru-latest
+        tags: zooproject/zoo-project:dru-latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 


### PR DESCRIPTION
# Overview
This PR updates the GitHub CodeQL SARIF upload action from v3 to v4 in the Docker DRU image workflow.
The change removes the GitHub Actions deprecation warning related to the SARIF upload step and keeps the workflow aligned with the latest supported CodeQL action version.

# Related Issue / Discussion
- Follow-up improvement after integrating Trivy SARIF scanning into the DRU Docker image workflow.
- Addresses the GitHub Actions warning about github/codeql-action/upload-sarif@v3 deprecation.
# Additional Information
Updated:
github/codeql-action/upload-sarif@v3 to github/codeql-action/upload-sarif@v4
Existing SARIF upload behavior remains unchanged.
# Contributions and Licensing

(as per https://zoo-project.github.io/docs/contribute/howto.html#licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.
- [x] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
