### PR TITLE
Enhance advanced installation documentation for ZOO-Project

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -6,7 +6,7 @@ This section explains how to install and run ZOO-Project.
 For most users, the recommended way to start is with Docker,
 as it provides a consistent environment across platforms.
 
-Quick Start
+Quick Start (Recommended)
 -------------------------
 
 Requirements
@@ -71,7 +71,7 @@ These files can be adjusted to customize your local deployment.
 
 
 Additional Installation Methods
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------
 
 For manual installation or custom deployments, see:
 

--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -6,7 +6,7 @@ This section explains how to install and run ZOO-Project.
 For most users, the recommended way to start is with Docker,
 as it provides a consistent environment across platforms.
 
-Quick Start (Recommended)
+Quick Start
 -------------------------
 
 Requirements
@@ -64,14 +64,14 @@ Configuration
 The default Docker setup uses the following files:
 
 - ``docker-compose.yml``
-- ``docker/main.cfg``
-- ``docker/oas.cfg``
+- `docker/main.cfg <../kernel/configuration.html#main-configuration-file>`_
+- `docker/oas.cfg <../kernel/configuration.html#openapi-specification-configuration-file>`_
 
 These files can be adjusted to customize your local deployment.
 
 
 Additional Installation Methods
--------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For manual installation or custom deployments, see:
 


### PR DESCRIPTION
# Overview
This PR improves the installation documentation structure.
# Related Issue / Discussion

# Additional Information
- Updated the Installation Guide configuration section:
  - Added link to `main.cfg` configuration documentation
  - Added link to `oas.cfg` configuration documentation
# Contributions and Licensing

(as per https://zoo-project.github.io/docs/contribute/howto.html#licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to ZOO-Project. I confirm that my contributions to ZOO-Project will be compatible with the ZOO-Project license guidelines at the time of contribution.
- [x] I have already previously agreed to the ZOO-Project Contributions and Licensing Guidelines
